### PR TITLE
Change mkdir to mkdir -p in scripts

### DIFF
--- a/virtualhost-nginx.sh
+++ b/virtualhost-nginx.sh
@@ -50,7 +50,7 @@ if [ "$action" == 'create' ]
 		### check if directory exists or not
 		if ! [ -d $userDir$rootDir ]; then
 			### create the directory
-			mkdir $userDir$rootDir
+			mkdir -p $userDir$rootDir
 			### give permission to root dir
 			chmod 755 $userDir$rootDir
 			### write test file in the new domain dir

--- a/virtualhost.sh
+++ b/virtualhost.sh
@@ -54,7 +54,7 @@ if [ "$action" == 'create' ]
 		### check if directory exists or not
 		if ! [ -d $rootDir ]; then
 			### create the directory
-			mkdir $rootDir
+			mkdir -p $rootDir
 			### give permission to root dir
 			chmod 755 $rootDir
 			### write test file in the new domain dir


### PR DESCRIPTION
Self explanatory, but might be a nice little addition. I tend to create a public folder in the folder from which the website will be served. It looks like this:
```
- my-website
    - my-application
    - public
        - index.php (starts application from ../my-application)
```

So both the 'my-website' and public folder have to be created, which makes `mkdir -p` necessary.