### PR TITLE
minimize nginx downtime

### DIFF
--- a/virtualhost-nginx.sh
+++ b/virtualhost-nginx.sh
@@ -144,7 +144,7 @@ if [ "$action" == 'create' ]
 		ln -s $sitesAvailable$domain $sitesEnable$domain
 
 		### restart Nginx
-		service nginx restart
+		systemctl reload nginx
 
 		### show the finished message
 		echo -e $"Complete! \nYou now have a new Virtual Host \nYour new host is: http://$domain \nAnd its located at $rootDir"
@@ -170,7 +170,7 @@ if [ "$action" == 'create' ]
 			rm $sitesEnable$domain
 
 			### restart Nginx
-			service nginx restart
+			systemctl reload nginx
 
 			### Delete virtual host rules files
 			rm $sitesAvailable$domain


### PR DESCRIPTION
This pull request seeks to replace nginx restart with nginx reload.

An nginx restart causes server downtime, and should only occur on significant configuration changes such as port or interface update.

To add/remove virtual host, updating configuration using nginx reload is a graceful way to minimize downtime.

More info: https://phoenixnap.com/kb/nginx-start-stop-restart
